### PR TITLE
Prevent error in error handling for file-less err

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,9 +41,16 @@ const findLessOrEqual = (haystack, needle) => {
 };
 
 const errPos = err => {
-  const lineIndex = findLessOrEqual(err.file.lineMap, err.start);
+  const errFile = err.file;
+  if (errFile) {
+    const lineMap = err.file.lineMap;
+    if (lineMap) {
+      const lineIndex = findLessOrEqual(lineMap, err.start);
 
-  return `Line: ${lineIndex + 1}, Col: ${err.start - err.file.lineMap[lineIndex] + 1}`;
+      return `Line: ${lineIndex + 1}, Col: ${err.start - err.file.lineMap[lineIndex] + 1}`;
+    }
+  }
+  return 'No line map'
 };
 
 const toMeaningfulMessage = err => `Error ${err.code}: ${err.messageText} (${errPos(err)})`;


### PR DESCRIPTION
Error handling previously would throw an error if the original error was not associated with a file.  For example, if typescript compiler throws error: Error 5053: Option 'lib' cannot be specified with option 'noLib'