### PR TITLE
Respect vendor conventions

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,7 @@ class TypeScriptCompiler {
     delete this.options.moduleResolution;
 
     this.options.sourceMap = !!config.sourceMaps;
-    this.isIgnored = anymatch(options.ignore || /(^bower_components|vendor|node_modules)/);
-
+    this.isIgnored = anymatch(options.ignore || config.conventions.vendor);
     if (this.options.pattern) {
       this.pattern = this.options.pattern;
       delete this.options.pattern;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-brunch",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Adds TypeScript support to Brunch.",
   "author": "Baptiste Donaux <baptiste.donaux@gmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-brunch",
-  "version": "2.3.1",
+  "version": "2.3.0",
   "description": "Adds TypeScript support to Brunch.",
   "author": "Baptiste Donaux <baptiste.donaux@gmail.com>",
   "contributors": [


### PR DESCRIPTION
Resolves issue #37  by using `conventions` values from Brunch configuration.