### PR TITLE
Emit js/jsx files using new targetExtension API

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,12 @@ class TypeScriptCompiler {
       this.options[key] = options[key];
     });
 
+    if (this.options.jsx === 'preserve') {
+      this.targetExtension = '.jsx';
+    } else {
+      this.targetExtension = '.js';
+    }
+
     this.options.module = resolveEnum(this.options.module, ts.ModuleKind);
     this.options.target = resolveEnum(this.options.target, ts.ScriptTarget);
     this.options.jsx = resolveEnum(this.options.jsx, ts.JsxEmit);


### PR DESCRIPTION
Newer versions of brunch (>2.10) have a targetExtension API which allows changing the extension of the file as it moves to the next stage of the pipeline. It's necessary to change this to `.js` or `.jsx` since that's what the Typescript compiler outputs, and otherwise it will get ignored by further stages (e.g. babel).

The targetExtension is changed based on the jsx option passed to the Typescript compiler (see https://www.typescriptlang.org/docs/handbook/jsx.html)

Also addresses https://github.com/brunch/typescript-brunch/issues/34