### PR TITLE
Make TypeScript a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Adds TypeScript support to [Brunch](http://brunch.io).
 
 ## Usage
 
-Install the plugin via NPM with `npm install --save-dev typescript-brunch`.
+Install the plugin and TypeScript via NPM with `npm install --save-dev typescript-brunch typescript`.
 
 Or, do manual install:
 
-* Add `"typescript-brunch": "x.y"` to `package.json` of your brunch app. Pick a plugin version that corresponds to your major.minor (x.y) Brunch version.
+* Add `"typescript-brunch": "x.y"` to `package.json` of your brunch app. Pick a plugin version that corresponds to your major.minor (x.y) Brunch version. You still need to install TypeScript manually `npm install --save-dev typescript`.
 * If you want to use git version of plugin, add
 `"typescript-brunch": "github:brunch/typescript-brunch"`.
 

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "anymatch": "^1.3.0",
-    "typescript": "2.1.*"
+    "anymatch": "^1.3.0"
   },
   "devDependencies": {
     "eslint": "^3.15.0",
     "eslint-config-brunch": "^1.0.0"
   },
   "peerDependencies": {
-    "brunch": "^2.2.0"
+    "brunch": "^2.2.0",
+    "typescript": "^2.0.0"
   },
   "eslintConfig": {
     "extends": "brunch"


### PR DESCRIPTION
Make TypeScript a peerDependency instead of a static dependency to allow user defined TypeScirpt versions