### PR TITLE
Enlarged the TypeScript version range to include v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "brunch": "^2.2.0",
-    "typescript": "^2.0.0"
+    "typescript": "^3.0.0 || ^2.0.0"
   },
   "eslintConfig": {
     "extends": "brunch"


### PR DESCRIPTION
Added TypeScript v3.x to the rage of acceptable peer dependencies.  Now it will allow any v2.x or v3.x to satisfy the peer dependency.