### PR TITLE
Strip // comments from tsconfig.json before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,10 +41,9 @@ const getTsconfig = configRoot => {
 
   // Parse the JSON into an object.
   const options = JSON.parse(json);
-  
+
   // Use default compiler options if none present.
-  if (options.compilerOptions === undefined)
-  {
+  if (options.compilerOptions === undefined) {
     return {};
   }
   return options.compilerOptions;

--- a/index.js
+++ b/index.js
@@ -30,12 +30,24 @@ const getTsconfig = configRoot => {
   // Read the contents of the JSON file.
   let json = fs.readFileSync(file, {encoding: 'utf8'});
 
-  // Strip // comments.  Stripping /**/ comments is more difficult and it's
-  // not clear if those are permitted in tsconfig.json anyway.
+  // Strip // comments.
+  //
+  // GOTCHA: This is very naive, and doesn't avoid stripping '//' from JSON
+  // strings.
+  //
+  // Don't bother stripping /**/ comments since it's not clear if those are
+  // permitted in tsconfig.json anyway.
   json = json.replace(/\/\/.*\r?\n/g, '');
 
   // Parse the JSON into an object.
-  return JSON.parse(json);
+  const options = JSON.parse(json);
+  
+  // Use default compiler options if none present.
+  if (options.compilerOptions === undefined)
+  {
+    return {};
+  }
+  return options.compilerOptions;
 };
 
 const findLessOrEqual = (haystack, needle) => {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const transpileModule = require('./transpile');
 const ts = require('typescript');
 const anymatch = require('anymatch');
 const path = require('path');
+const fs = require('fs');
 
 const resolveEnum = (choice, opts) => {
   const defaultValue = 1; // CommonJS/ES5/Preserve JSX defaults
@@ -20,16 +21,21 @@ const resolveEnum = (choice, opts) => {
   return defaultValue;
 };
 
+// Throws an error if the config cannot be read or parsed.
 const getTsconfig = configRoot => {
   if (!configRoot) return {};
 
   const file = path.resolve(configRoot, 'tsconfig.json');
 
-  try {
-    return require(file).compilerOptions;
-  } catch (e) {
-    return {};
-  }
+  // Read the contents of the JSON file.
+  let json = fs.readFileSync(file, {encoding: 'utf8'});
+
+  // Strip // comments.  Stripping /**/ comments is more difficult and it's
+  // not clear if those are permitted in tsconfig.json anyway.
+  json = json.replace(/\/\/.*\r?\n/g, '');
+
+  // Parse the JSON into an object.
+  return JSON.parse(json);
 };
 
 const findLessOrEqual = (haystack, needle) => {

--- a/index.js
+++ b/index.js
@@ -30,14 +30,9 @@ const getTsconfig = configRoot => {
   // Read the contents of the JSON file.
   let json = fs.readFileSync(file, {encoding: 'utf8'});
 
-  // Strip // comments.
-  //
-  // GOTCHA: This is very naive, and doesn't avoid stripping '//' from JSON
-  // strings.
-  //
-  // Don't bother stripping /**/ comments since it's not clear if those are
-  // permitted in tsconfig.json anyway.
-  json = json.replace(/\/\/.*\r?\n/g, '');
+  // Strip // and /**/ comments from the JSON, preserving those found within
+  // JSON strings.
+  json = json.replace(/\/\/.*|\/\*[\s\S]*?\*\/|("(\\.|[^"])*")/g, '$1');
 
   // Parse the JSON into an object.
   const options = JSON.parse(json);

--- a/test/test_getTsconfig.js
+++ b/test/test_getTsconfig.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// ***************************************************************************
+// Test the reading and parsing of tsconfig.json.
+
+'use strict';
+
+const TypeScriptCompiler = require('../index');
+
+// Setup a config that looks for './tsconfig.json'.
+const config = {
+  paths: {root: __dirname},
+  conventions: {vendor: ''},
+};
+
+// Create a compiler, which will read ad parse the tsconfig.json.
+const compiler = new TypeScriptCompiler(config);
+
+// Setup the expected stringified tsconfig.json.  Note that the compiler only
+// keeps the 'compilerOptions' part.
+const expected =
+  '{' +
+    '"foo":"Should // not be stripped",' +
+    '"bar":"Should /* not be */ stripped",' +
+    '"baz":true,' +
+    '"fud":[1,2,3],' +
+    // The compiler adds a bunch of options in addition to what was in
+    // tsconfig.json.
+    '"module":1,' +
+    '"target":1,' +
+    '"jsx":1,' +
+    '"emitDecoratorMetadata":true,' +
+    '"experimentalDecorators":true,' +
+    '"noEmitOnError":false,' +
+    '"sourceMap":false' +
+  '}';
+
+// Compare actual and expected; no need for a fancy test framework just for
+// this.
+const actual = JSON.stringify(compiler.options);
+if (actual === expected) {
+  console.log('PASS');
+} else {
+  console.error(`FAIL:\nActual:\n${actual}\nExpected:\n${expected}`);
+  process.exitCode = 1;
+}
+
+// ***************************************************************************

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,17 @@
+// This is a sample tsconfig.json.  All comments should be stripped before it
+// is parsed as JSON.
+{
+  /* Should be stripped */
+  "compilerOptions":
+  {
+    // Should be stripped.
+    "foo": "Should // not be stripped",
+    "bar": "Should /* not be */ stripped",
+    "baz": true,
+    "fud": [1,2,3]
+  },
+  // Ignored fields.
+  "ignored": 98,
+  "ignoredToo": ["a","b","c"]
+}
+// Also stripped /* no really */


### PR DESCRIPTION
Updated plugin construction to strip // comments from tsconfig.json before parsing it, and letting errors bubble up to produce a warning message when parsing fails.  Fix for #29.